### PR TITLE
Fix non-persistent semester tag in AddModule component

### DIFF
--- a/src/app/components/AddModule.jsx
+++ b/src/app/components/AddModule.jsx
@@ -27,7 +27,7 @@ const AddModule = ({currentSemester}) => {
     const [grade, setGrade] = useState("");
     const [units, setUnits] = useState(4);
     const [tags, setTags] = useState([]);
-    const [semester, setSemester] = useState([currentSemester]);
+    const [semester, setSemester] = useState([]);
     const [isOpen, setIsOpen] = useState(false);
     const [errors, setErrors] = useState({});
     const options = Object.keys(data.semesters);
@@ -71,11 +71,19 @@ const AddModule = ({currentSemester}) => {
         return Object.keys(newErrors).length === 0;
     }
 
+    const handleOpenChange = (open) => {
+        setIsOpen(open);
+        if (open) {
+            setSemester([currentSemester]);
+        } else {
+            clearData();
+        }
+    }
 
 
     return (
         <Dialog open={isOpen}
-                onOpenChange={setIsOpen}
+                onOpenChange={handleOpenChange}
                 className={`flex flex-col h-full w-100`}>
             <DialogTrigger asChild>
                 <Button variant="outline"


### PR DESCRIPTION
This PR fixes #1 

The behaviour was caused by the clearing of the _semester tag_ data upon the calling `clearData` but no handler was set to re-set the appropriate semester tag after the initial semester state was set.